### PR TITLE
changed extract_app to extract_app_in_dir

### DIFF
--- a/lib/redis_console.rb
+++ b/lib/redis_console.rb
@@ -4,7 +4,7 @@ class Heroku::Command::Redis < Heroku::Command::Base
   def cli(*queries)
     # Must remember to extract these so they don't get passed to redis-cli
     db = extract_option("--db") || 'REDISTOGO_URL'
-    app = extract_app
+    app = extract_app_in_dir(".")
 
     redis_url = heroku.config_vars(app)[db]
     return puts "No such redis (#{db}), try setting --db REDIS_URL." unless redis_url


### PR DESCRIPTION
will make this script work with the heroku base from Dec 8 2011 where extract_app was removed, I just changed to use app_in_dir targeting current folder same behavior as before
