### PR TITLE
Remove deprecated methods

### DIFF
--- a/lib/redis_console.rb
+++ b/lib/redis_console.rb
@@ -4,9 +4,8 @@ class Heroku::Command::Redis < Heroku::Command::Base
   def cli(*queries)
     # Must remember to extract these so they don't get passed to redis-cli
     db = extract_option("--db") || 'REDISTOGO_URL'
-    app = extract_app
 
-    redis_url = heroku.config_vars(app)[db]
+    redis_url = api.get_config_vars(app).body[db]
     return puts "No such redis (#{db}), try setting --db REDIS_URL." unless redis_url
     uri = URI.parse(redis_url)
 


### PR DESCRIPTION
- Command::Base#extract_app
  - to Command::Base#app
- Heroku::Client#config_vars
  - to Heroku::API#get_config_vars

```
$ heroku redis:monitor
 !    Command::Base#extract_app has been deprecated. Please use Command::Base#app instead.  /path/to/plugins/heroku-redis-cli/lib/redis_console.rb:7:in `cli'
 !    DEPRECATED: Heroku::Client#deprecate is deprecated, please use the heroku-api gem.
 !    DEPRECATED: More information available at https://github.com/heroku/heroku.rb
 !    DEPRECATED: Deprecated method called from /path2/to/heroku-2.31.1/lib/heroku/client.rb:129.
OK
1346336246.034468 "monitor"
```
